### PR TITLE
🧹 Delete corrupt model file after failed hash check

### DIFF
--- a/photonix/classifiers/base_model.py
+++ b/photonix/classifiers/base_model.py
@@ -104,7 +104,7 @@ class BaseModel:
                         error = True
                         logger.error(f"File downloaded from {location} is "
                                      "corrupt as indicated by bad hash")
-                        # TODO: Delete badly downloaded file
+                        os.remove(f.name)
 
             # Write version file
             with open(version_file, 'w') as f:


### PR DESCRIPTION
This PR addresses the issue where temporary model files were left on disk after a failed hash verification check during the download process in `BaseModel.ensure_downloaded`.

Changes:
- Added `os.remove(f.name)` in the `else` block where the SHA256 hash check fails in `photonix/classifiers/base_model.py`.
- This ensures that corrupt or incomplete model files are cleaned up immediately, preventing the accumulation of unnecessary files in the system.

Verification:
- The change was verified through a reproduction test case that mocked a failed hash check and asserted the deletion of the temporary file.
- Code review confirmed the fix is correct and safe for Unix-like environments.
- Syntax integrity was verified using `compileall`.

---
*PR created automatically by Jules for task [3559475280361502514](https://jules.google.com/task/3559475280361502514) started by @aashishbhanawat*