### PR TITLE
⚡ Optimize SetPhotosDeleted mutation to avoid N+1 update issue

### DIFF
--- a/photonix/photos/schema.py
+++ b/photonix/photos/schema.py
@@ -4,6 +4,7 @@ import django_filters
 import graphene
 from django.conf import settings
 from django.contrib.auth import get_user_model, load_backend, login
+from django.utils import timezone
 from django.db.models import Case, IntegerField, Value, When
 from django.db.models.functions import Lower
 from django_filters import CharFilter, OrderingFilter
@@ -1184,10 +1185,9 @@ class SetPhotosDeleted(graphene.Mutation):
         """Mutation to set delete field true for a photo objects."""
         user = info.context.user
         try:
-            photo_list = Photo.objects.filter(id__in=photo_ids.split(','), library__users__user=user)
-            for photo in photo_list:
-                photo.deleted = True
-                photo.save()
+            Photo.objects.filter(
+                id__in=photo_ids.split(','), library__users__user=user
+            ).update(deleted=True, updated_at=timezone.now())
             return SetPhotosDeleted(ok=True)
         except Exception as e:
             raise GraphQLError("Something Went wrong!")


### PR DESCRIPTION
💡 **What:** Replaced the loop in `SetPhotosDeleted.mutate` that called `.save()` on each `Photo` object with a single bulk `.update()` call on the filtered QuerySet. Included `updated_at=timezone.now()` to ensure timestamps are accurately maintained.

🎯 **Why:** The original implementation performed $N$ database updates for $N$ photos, leading to an N+1 performance bottleneck. Using `.update()` reduces this to a single database operation.

📊 **Measured Improvement:** Baseline measurements in the sandbox environment were impractical due to missing dependencies and lack of internet access to install them. However, reducing database writes from $O(N)$ to $O(1)$ is a well-established optimization in Django.

---
*PR created automatically by Jules for task [1704075682550311833](https://jules.google.com/task/1704075682550311833) started by @aashishbhanawat*