### PR TITLE
Restore 'I' keyboard shortcut for photo details

### DIFF
--- a/ui/src/components/PhotoDetail.js
+++ b/ui/src/components/PhotoDetail.js
@@ -23,7 +23,7 @@ import { ReactComponent as RotateRightIcon } from '../static/images/rotate_right
 
 import photos from '../stores/photos/index'
 
-// const I_KEY = 73
+const I_KEY = 73
 const LEFT_KEY = 37
 const RIGHT_KEY = 39
 const BEFORE = 'before'
@@ -169,25 +169,6 @@ const PhotoDetail = ({
   const timelinePhotoIds = useSelector(photos)
   const [showTopIcons, setShowTopIcons] = useState(true)
 
-  // TODO: Bring this back so it doesn't get triggered by someone adding a tag with 'i' in it
-  // useEffect(() => {
-  //   const handleKeyDown = (event) => {
-  //     switch (event.keyCode) {
-  //       case I_KEY:
-  //         setShowMetadata(!showMetadata)
-  //         break
-  //       default:
-  //         break
-  //     }
-  //   }
-
-  //   document.addEventListener('keydown', handleKeyDown)
-
-  //   return () => {
-  //     document.removeEventListener('keydown', handleKeyDown)
-  //   }
-  // }, [showMetadata])
-
   const { data: photosData, fetchMore: fetchMorePhotos } = useQuery(
     GET_PHOTOS,
     {
@@ -296,7 +277,18 @@ const PhotoDetail = ({
 
   useEffect(() => {
     const handleKeyDown = (event) => {
+      if (
+        event.target.tagName === 'INPUT' ||
+        event.target.tagName === 'TEXTAREA' ||
+        event.target.isContentEditable
+      ) {
+        return
+      }
+
       switch (event.keyCode) {
+        case I_KEY:
+          setShowMetadata((prev) => !prev)
+          break
         case LEFT_KEY:
           prevPhoto()
           break
@@ -419,7 +411,7 @@ const PhotoDetail = ({
                 height="30"
                 width="30"
                 onClick={() => setShowMetadata(!showMetadata)}
-                // title="Press [I] key to show/hide photo details"
+                title="Press [I] key to show/hide photo details"
               />
             ) : (
               <CloseIcon
@@ -427,7 +419,7 @@ const PhotoDetail = ({
                 height="30"
                 width="30"
                 onClick={() => setShowMetadata(!showMetadata)}
-                // title="Press [I] key to show/hide photo details"
+                title="Press [I] key to show/hide photo details"
               />
             )}
           </div>


### PR DESCRIPTION
This change restores the 'I' key keyboard shortcut in the PhotoDetail component, allowing users to toggle photo metadata. It also improves the robustness of all keyboard shortcuts in this component by ensuring they are ignored when the user is typing in form fields or content-editable elements.

---
*PR created automatically by Jules for task [15207705659881745514](https://jules.google.com/task/15207705659881745514) started by @aashishbhanawat*